### PR TITLE
Add "an"

### DIFF
--- a/draft-irtf-cfrg-aegis-aead.md
+++ b/draft-irtf-cfrg-aegis-aead.md
@@ -261,7 +261,7 @@ Primitives:
 - `a & b`: the bitwise AND operation between `a` and `b`.
 - `a || b`: the concatenation of `a` and `b`.
 - `a mod b`: the remainder of the Euclidean division between `a` as the dividend and `b` as the divisor.
-- `LE64(x)`: the little-endian encoding of unsigned 64-bit integer `x`.
+- `LE64(x)`: the little-endian encoding of an unsigned 64-bit integer `x`.
 - `ZeroPad(x, n)`: padding operation. Trailing zeros are concatenated to `x` until the total length is a multiple of `n` bits.
 - `Truncate(x, n)`: truncation operation. The first `n` bits of `x` are kept.
 - `Split(x, n)`: splitting operation. `x` is split into `n`-bit blocks, ignoring partial blocks.


### PR DESCRIPTION
Ran the document through Google spelling/grammar check as well as Antidote, and this is all they found so far.

I don't even think the "an" is necessary, but you are the judge :)