### PR TITLE
Change setup phase to initialization function

### DIFF
--- a/draft-irtf-cfrg-aegis-aead.md
+++ b/draft-irtf-cfrg-aegis-aead.md
@@ -320,7 +320,7 @@ In AEGIS, finding distinct (key, nonce) pairs that successfully decrypt a given 
 
 Unlike most other AES-based AEAD constructions, leaking a state does not leak the key or previous states.
 
-Finally, an AEGIS key is not required after the setup phase, and there is no key schedule. Thus, ephemeral keys can be erased from memory before any data has been encrypted or decrypted, mitigating cold boot attacks.
+Finally, an AEGIS key is not required after the initialization function, and there is no key schedule. Thus, ephemeral keys can be erased from memory before any data has been encrypted or decrypted, mitigating cold boot attacks.
 
 Note that an earlier version of Hongjun Wu and Bart Preneel's paper introducing AEGIS specified AEGIS-128L and AEGIS-256 sporting differences with regards to the computation of the authentication tag and the number of rounds in the `Finalize()` function. We follow the specification of {{AEGIS}}, which can be found in the References section of this document.
 


### PR DESCRIPTION
Part of #50.

Or we could say `after initialization`. I didn't want to name `Init()` since it hasn't been defined yet.