### PR TITLE
128X-MAC: properly absorb all concatenated tags into the first lane

### DIFF
--- a/draft-irtf-cfrg-aegis-aead.md
+++ b/draft-irtf-cfrg-aegis-aead.md
@@ -1735,8 +1735,8 @@ else:              # 256 bits
 if D > 1:
     # Absorb tags into state 0; other states are not used anymore
     for v in Split(tags, 256):
-        x = Split(v, 128)
-        Absorb(ZeroPad(x[0], R / 2) || ZeroPad(x[1], R / 2))
+        x0, x1 = Split(v, 128)
+        Absorb(ZeroPad(x0, R / 2) || ZeroPad(x1, R / 2))
 
     u = LE64(D) || LE64(tag_len_bits)
     t = ZeroPad(V[2,0] ^ u, R)

--- a/draft-irtf-cfrg-aegis-aead.md
+++ b/draft-irtf-cfrg-aegis-aead.md
@@ -1735,7 +1735,8 @@ else:              # 256 bits
 if D > 1:
     # Absorb tags into state 0; other states are not used anymore
     for v in Split(tags, 256):
-        Absorb(ZeroPad(v, R))
+        x = Split(v, 128)
+        Absorb(ZeroPad(x[0], R / 2) || ZeroPad(x[1], R / 2))
 
     u = LE64(D) || LE64(tag_len_bits)
     t = ZeroPad(V[2,0] ^ u, R)
@@ -2793,13 +2794,13 @@ data   : 000102030405060708090a0b0c0d0e0f
 tags128: 9f5f69928fa481fa86e8a51e072a9b29
          eeaa77a356f796b427f6a54f52ae0e20
 
-tag128 : 7aa41edfd57a95c1108d83c63b8d4d01
+tag128 : 6873ee34e6b5c59143b6d35c5e4f2c6e
 
 tags256: 22cdcf558d0338b6ad8fbba4da7307d3
          0bd685fff23dc9d41f598c2a7ea44055
 
-tag256 : 55b6449929cd2b01d04786e57698b3dd
-         fb5cbf6e421bbd022637a33d60f40294
+tag256 : afcba3fc2d63c8d6c7f2d63f3ec8fbbb
+         af022e15ac120e78ffa7755abccd959c
 ~~~
 
 ### AEGISMAC-128X4 Test Vector
@@ -2818,7 +2819,7 @@ tags128: 7fecd913a7cb0011b6c4c88e0c6f8578
          c7b5e6625a5765d04af26cf22adc1282
          4c8cf3b4dbb85f379e13b04a8d06bca7
 
-tag128 : 46a194ea4337bb32c2186a99e312f3a7
+tag128 : c45a98fd9ab8956ce616eb008cfe4e53
 
 tags256: d595732bdf230a1441978414cd8cfa39
          ecef6ad0ee1e65ae530006ca5d5f4481
@@ -2827,8 +2828,8 @@ tags256: d595732bdf230a1441978414cd8cfa39
          1264a15143eb8c3d9f17754099f147e3
          401c83c0d5afc70fd0d68bfd17f9280f
 
-tag256 : ea884072699569532fb68ae9fb2653c9
-         ffef3e974333d3a17d77be02453cc12f
+tag256 : 26fdc76f41b1da7aec7779f6e964beae
+         8904e662f05aca8345ae3befb357412a
 ~~~
 
 ### AEGISMAC-256 Test Vector

--- a/reference-implementations/aegis128x.zig
+++ b/reference-implementations/aegis128x.zig
@@ -201,14 +201,16 @@ fn Aegis128X_(comptime degree: u7, comptime tag_bits: u9) type {
             if (tag_length == 16) {
                 const tags = s[0].xorBlocks(s[1]).xorBlocks(s[2]).xorBlocks(s[3]).xorBlocks(s[4]).xorBlocks(s[5]).xorBlocks(s[6]).toBytes();
                 for (0..degree / 2) |d| {
-                    v[0..32].* = tags[d * 32 ..][0..32].*;
+                    v[0..16].* = tags[d * 32 ..][0..16].*;
+                    v[rate / 2..][0..16].* = tags[d * 32 ..][16..32].*;
                     self.absorb(&v);
                 }
             } else {
                 const tags_0 = s[0].xorBlocks(s[1]).xorBlocks(s[2]).xorBlocks(s[3]).toBytes();
                 const tags_1 = s[4].xorBlocks(s[5]).xorBlocks(s[6]).xorBlocks(s[7]).toBytes();
                 for (1..degree) |d| {
-                    v[0..32].* = tags_0[d * 16 ..][0..16].* ++ tags_1[d * 16 ..][0..16].*;
+                    v[0..16].* = tags_0[d * 16 ..][0..16].*;
+                    v[rate / 2..][0..16].* = tags_1[d * 16 ..][0..16].*;
                     self.absorb(&v);
                 }
             }


### PR DESCRIPTION
The `FinalizeMac` function concatenates the tags from all AEGIS instances and absorbs them into the first state, following the behavior of AEGIS-128L.

However, the `Update` function referenced here belongs to AEGIS-128X.

When the degree is greater than 1, bytes [16..32] correspond to the second AEGIS instance (or, in implementations, the second half of a 256-bit register), rather than the first instance.

Adjust the padding to ensure all bytes are correctly loaded into the first instance.