### PR TITLE
Fix collision probability typo

### DIFF
--- a/draft-irtf-cfrg-aegis-aead.md
+++ b/draft-irtf-cfrg-aegis-aead.md
@@ -1838,7 +1838,7 @@ Every key MUST be randomly chosen from a uniform distribution.
 
 The nonce MAY be public or predictable. It can be a counter, the output of a permutation, or a generator with a long period.
 
-With AEGIS-128L and AEGIS-128X, random nonces can safely encrypt up to 2<sup>48</sup> messages using the same key with negligible (~2<sup>-33</sup>, to align with NIST guidelines) collision probability.
+With AEGIS-128L and AEGIS-128X, random nonces can safely encrypt up to 2<sup>48</sup> messages using the same key with negligible (2<sup>-32</sup>, to align with NIST guidelines) collision probability.
 
 With AEGIS-256 and AEGIS-256X, random nonces can be used with no practical limits.
 


### PR DESCRIPTION
I believe the 2<sup>-33</sup> is a [typo](https://csrc.nist.gov/pubs/sp/800/38/d/final). I think I left it before because the `~` made it look intentional.